### PR TITLE
Fixed inventory transfer

### DIFF
--- a/common/src/main/java/earth/terrarium/reaper/client/screen/ReaperGeneratorScreen.java
+++ b/common/src/main/java/earth/terrarium/reaper/client/screen/ReaperGeneratorScreen.java
@@ -35,10 +35,10 @@ public class ReaperGeneratorScreen extends AbstractContainerScreen<ReaperGenerat
         super.init();
         var boxComponents = addRenderableWidget(new SelectionList<DeferredInfographic>(leftPos + 11, topPos + 20, 79, 68, 10, entry -> {}));
         boxComponents.updateEntries(List.of(
-                new DeferredInfographic(() -> Component.translatable("gui.reaper.energy", this.menu.data.get(ReaperGeneratorData.PRODUCTION)).withStyle(ChatFormatting.GRAY)),
-                new DeferredInfographic(() -> Component.translatable("gui.reaper.work", this.menu.data.get(ReaperGeneratorData.MAX_COOLDOWN)).withStyle(ChatFormatting.GRAY)),
-                new DeferredInfographic(() -> Component.translatable("gui.reaper.range", this.menu.data.get(ReaperGeneratorData.RANGE)).withStyle(ChatFormatting.GRAY)),
-                new DeferredInfographic(() -> Component.translatable(this.menu.data.get(ReaperGeneratorData.DAMAGE) > 0 ? "gui.reaper.damage" : "gui.reaper.instadeath", this.menu.data.get(ReaperGeneratorData.DAMAGE)).withStyle(ChatFormatting.GRAY))
+                new DeferredInfographic(() -> Component.translatable("gui.reaper.energy", this.menu.getContainerData().get(ReaperGeneratorData.PRODUCTION)).withStyle(ChatFormatting.GRAY)),
+                new DeferredInfographic(() -> Component.translatable("gui.reaper.work", this.menu.getContainerData().get(ReaperGeneratorData.MAX_COOLDOWN)).withStyle(ChatFormatting.GRAY)),
+                new DeferredInfographic(() -> Component.translatable("gui.reaper.range", this.menu.getContainerData().get(ReaperGeneratorData.RANGE)).withStyle(ChatFormatting.GRAY)),
+                new DeferredInfographic(() -> Component.translatable(this.menu.getContainerData().get(ReaperGeneratorData.DAMAGE) > 0 ? "gui.reaper.damage" : "gui.reaper.instadeath", this.menu.getContainerData().get(ReaperGeneratorData.DAMAGE)).withStyle(ChatFormatting.GRAY))
         ));
     }
 
@@ -54,15 +54,15 @@ public class ReaperGeneratorScreen extends AbstractContainerScreen<ReaperGenerat
     }
 
     public Supplier<Integer> getEnergyLevel() {
-        return () -> menu.data.get(ReaperGeneratorData.ENERGY);
+        return () -> menu.getContainerData().get(ReaperGeneratorData.ENERGY);
     }
 
     public Supplier<Integer> getTicks() {
-        return () -> menu.data.get(ReaperGeneratorData.COOLDOWN);
+        return () -> menu.getContainerData().get(ReaperGeneratorData.COOLDOWN);
     }
 
     public Supplier<Integer> getMaxTicks() {
-        return () -> menu.data.get(ReaperGeneratorData.MAX_COOLDOWN);
+        return () -> menu.getContainerData().get(ReaperGeneratorData.MAX_COOLDOWN);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/reaper/common/block/ReaperGeneratorBlock.java
+++ b/common/src/main/java/earth/terrarium/reaper/common/block/ReaperGeneratorBlock.java
@@ -20,6 +20,10 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@SuppressWarnings("deprecation")
+@ParametersAreNonnullByDefault
 public class ReaperGeneratorBlock extends BaseEntityBlock {
     public static final VoxelShape SHAPE = box(0, 0, 0, 16, 8, 16);
 

--- a/common/src/main/java/earth/terrarium/reaper/common/block/SelfIdentifyingRuneBlock.java
+++ b/common/src/main/java/earth/terrarium/reaper/common/block/SelfIdentifyingRuneBlock.java
@@ -17,14 +17,16 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@SuppressWarnings("deprecation")
+@ParametersAreNonnullByDefault
 public class SelfIdentifyingRuneBlock extends BaseEntityBlock {
     public SelfIdentifyingRuneBlock(Properties properties) {
         super(properties);
     }
 
     //override use method to switch the whitelist mode
-
-
     @Override
     public InteractionResult use(BlockState blockState, Level level, BlockPos blockPos, Player player, InteractionHand interactionHand, BlockHitResult blockHitResult) {
         if(!level.isClientSide) {
@@ -33,14 +35,13 @@ public class SelfIdentifyingRuneBlock extends BaseEntityBlock {
                 if(player.getItemInHand(interactionHand).is(SpiritItems.SOUL_STEEL_WAND.get())) {
                     runeBlockEntity.toggleWhitelist();
                     player.displayClientMessage(Component.nullToEmpty("Whitelist mode: " + runeBlockEntity.isWhitelist()), true);
-                    return InteractionResult.SUCCESS;
                 } else {
                     Player playerByUUID = level.getPlayerByUUID(runeBlockEntity.getOwner());
                     if (playerByUUID != null) {
                         player.displayClientMessage(Component.translatable(runeBlockEntity.isWhitelist() ? "block.possessio_rune.whitelist" : "block.possessio_rune.blacklist", runeBlockEntity.getOwnerName()), true);
                     }
-                    return InteractionResult.SUCCESS;
                 }
+                return InteractionResult.SUCCESS;
             }
         }
         return InteractionResult.SUCCESS;
@@ -53,9 +54,9 @@ public class SelfIdentifyingRuneBlock extends BaseEntityBlock {
     }
 
     @Override
-    public void setPlacedBy(Level level, BlockPos blockPos, BlockState blockState, @Nullable LivingEntity livingEntity, ItemStack itemStack) {
-        super.setPlacedBy(level, blockPos, blockState, livingEntity, itemStack);
-        if(level.getBlockEntity(blockPos) instanceof SelfIdentifyingRuneBlockEntity rune && livingEntity != null && livingEntity instanceof Player player) {
+    public void setPlacedBy(Level level, BlockPos blockPos, BlockState blockState, @Nullable LivingEntity entity, ItemStack itemStack) {
+        super.setPlacedBy(level, blockPos, blockState, entity, itemStack);
+        if(level.getBlockEntity(blockPos) instanceof SelfIdentifyingRuneBlockEntity rune && entity instanceof Player player) {
             rune.setOwner(player);
         }
     }

--- a/common/src/main/java/earth/terrarium/reaper/common/block/SoulBeaconBlock.java
+++ b/common/src/main/java/earth/terrarium/reaper/common/block/SoulBeaconBlock.java
@@ -22,6 +22,10 @@ import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
 
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@SuppressWarnings("deprecation")
+@ParametersAreNonnullByDefault
 public class SoulBeaconBlock extends BaseEntityBlock {
     public static final VoxelShape SHAPE = box(0, 0, 0, 16, 8, 16);
 

--- a/common/src/main/java/earth/terrarium/reaper/common/blockentity/ReaperGeneratorBlockEntity.java
+++ b/common/src/main/java/earth/terrarium/reaper/common/blockentity/ReaperGeneratorBlockEntity.java
@@ -46,9 +46,11 @@ import software.bernie.geckolib3.core.event.predicate.AnimationEvent;
 import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
 
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.function.Predicate;
 
+@ParametersAreNonnullByDefault
 public class ReaperGeneratorBlockEntity extends BlockEntity implements EnergyBlock, ItemContainerBlock, IAnimatable, ExtraDataMenuProvider {
     private ExtractOnlyEnergyContainer energyContainer;
     private SimpleItemContainer itemContainer;
@@ -223,8 +225,8 @@ public class ReaperGeneratorBlockEntity extends BlockEntity implements EnergyBlo
     }
 
     @Override
-    public void writeExtraData(ServerPlayer player, FriendlyByteBuf buffer) {
-
+    public void writeExtraData(ServerPlayer player, FriendlyByteBuf buf) {
+        buf.writeBlockPos(this.getBlockPos());
     }
 
     @Override
@@ -235,7 +237,7 @@ public class ReaperGeneratorBlockEntity extends BlockEntity implements EnergyBlo
     @Nullable
     @Override
     public AbstractContainerMenu createMenu(int i, Inventory inventory, Player player) {
-        return new ReaperGeneratorMenu(this.getContainer(), new ReaperGeneratorData(this), i, inventory);
+        return new ReaperGeneratorMenu(this.getContainer(), new ReaperGeneratorData(this), i, inventory, this);
     }
 
     public int getMaxCooldown() {

--- a/common/src/main/java/earth/terrarium/reaper/common/registry/ReaperRegistry.java
+++ b/common/src/main/java/earth/terrarium/reaper/common/registry/ReaperRegistry.java
@@ -34,7 +34,7 @@ public class ReaperRegistry {
     public static RegistryHolder<Item> ITEMS = new RegistryHolder<>(Registry.ITEM, Reaper.MODID);
     public static RegistryHolder<Block> BLOCKS = new RegistryHolder<>(Registry.BLOCK, Reaper.MODID);
     public static RegistryHolder<BlockEntityType<?>> BLOCK_ENTITIES = new RegistryHolder<>(Registry.BLOCK_ENTITY_TYPE, Reaper.MODID);
-    //registry holder of sound events
+
     public static final RegistryHolder<SoundEvent> SOUNDS = new RegistryHolder<>(Registry.SOUND_EVENT, Reaper.MODID);
 
     public static final RegistryHolder<MenuType<?>> MENUS = new RegistryHolder<>(Registry.MENU, Reaper.MODID);

--- a/forge/src/main/java/earth/terrarium/reaper/client/forge/SoulBeaconRenderer.java
+++ b/forge/src/main/java/earth/terrarium/reaper/client/forge/SoulBeaconRenderer.java
@@ -2,9 +2,7 @@ package earth.terrarium.reaper.client.forge;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
-import earth.terrarium.reaper.client.block.ReaperGeneratorBlockModel;
 import earth.terrarium.reaper.client.block.SoulBeaconBlockModel;
-import earth.terrarium.reaper.common.blockentity.ReaperGeneratorBlockEntity;
 import earth.terrarium.reaper.common.blockentity.SoulBeaconBlockEntity;
 import net.minecraft.client.renderer.MultiBufferSource;
 import net.minecraft.client.renderer.RenderType;


### PR DESCRIPTION
- Fixed shift-clicking on items not transferring into the generator inventory.
- Fixed being able to take out the catalysts mid-animation.
- Cleaned a few warnings